### PR TITLE
parse_lists now works

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,3 +1,7 @@
+use serde::{Serialize, Deserialize};
+use serde_json::{Result, Value};
+
+#[derive(Debug, Clone)]
 pub struct Handler {
     
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut downloader = Downloader::new();
  
     downloader.download_lists("https://github.com/incontestableness/TF2BD-Community-Lists/raw/main/All.zip".to_string()).await?;
-    
 
     Ok(())
 }


### PR DESCRIPTION
Just need to search the damn lists for steam ids. Though for some awful reason some are in SteamID64 as an integer and others a SteamID3 string.
Maybe a web API to somehow convert SteamID3 strings to SteamID64 integers? Would be nice if you could mathematically convert them.

Signed-off-by: Mike <ash@trapacid.dev>